### PR TITLE
Don't replace spaces in passwords with underscores

### DIFF
--- a/src/routes/tools/goldretriever/+page.svelte
+++ b/src/routes/tools/goldretriever/+page.svelte
@@ -122,7 +122,7 @@
 					const issuesAndPacks = await parseXML(
 						`${domain}/cgi-bin/api.cgi?nation=${nation}&q=issues+packs`,
 						main,
-						nationSpecificPassword ? nationSpecificPassword : password.replaceAll(' ', '_')
+						nationSpecificPassword ? nationSpecificPassword : password
 					)
 					const packs = issuesAndPacks.NATION.PACKS
 					const issues: Issue = issuesAndPacks.NATION.ISSUES.ISSUE || []

--- a/src/routes/tools/gotissues/+page.svelte
+++ b/src/routes/tools/gotissues/+page.svelte
@@ -88,7 +88,7 @@
 				const xmlObj = await parseXML(
 					`${domain}/cgi-bin/api.cgi?nation=${nation}&q=issues+packs`,
 					main,
-					nationSpecificPassword ? nationSpecificPassword : password?.replaceAll(' ', '_')
+					nationSpecificPassword ? nationSpecificPassword : password
 				)
 				const packs = xmlObj.NATION.PACKS
 


### PR DESCRIPTION
Seems like both gotIssues and Gold Retriever (when the Include option is selected) try to replace spaces in the user's entered password with underscores. Obviously this causes the password check on the NS side to fail. This patch removes this substitution in both cases and passes the password along directly.