### PR TITLE
Cache region card IDs

### DIFF
--- a/src/lib/components/junkdajunk/rules/RuleEditor.svelte
+++ b/src/lib/components/junkdajunk/rules/RuleEditor.svelte
@@ -144,7 +144,7 @@
 						{:else if condition.operator === 'in list' || condition.operator === 'not in list'}
 							<FormTextArea
 								editor={true}
-								label="Values (newline or comma separated)"
+								label="Values (one per line)"
 								bind:bindValue={condition.value}
 								id={`val-${i}`} />
 						{:else}

--- a/src/lib/helpers/cardList.ts
+++ b/src/lib/helpers/cardList.ts
@@ -1,0 +1,21 @@
+export type CardListEntry = {
+	id: string
+	season: string
+	extra: string[]
+}
+
+export function parseCardList(value: string): CardListEntry[] {
+	return value
+		.split('\n')
+		.map(line => line.trim())
+		.filter(Boolean)
+		.map(line => {
+			const [id = '', season = '', ...extra] = line.split(',').map(part => part.trim())
+			return { id, season, extra }
+		})
+}
+
+export function cardListEntryMatches(entry: CardListEntry, id: string | number, season: string | number): boolean {
+	if (entry.id !== String(id)) return false
+	return !entry.season || entry.season === String(season)
+}

--- a/src/lib/helpers/rules.ts
+++ b/src/lib/helpers/rules.ts
@@ -1,5 +1,6 @@
 import type { Card } from '$lib/types'
 import { canonicalize } from '$lib/helpers/utils'
+import { cardListEntryMatches, parseCardList } from '$lib/helpers/cardList'
 
 export type Attribute =
     | 'Rarity'
@@ -217,9 +218,10 @@ export function evaluateCondition(
             return !normalizeString(cardValue).includes(normalizeString(value))
         case 'in list':
         case 'not in list': {
-            // Use newlines or commas to separate for lists
-            const list = splitConditionValues(value).map(s => normalizeString(s)).filter(Boolean)
-            const inList = list.includes(normalizeString(cardValue))
+            // supports id and id,season
+            const inList = attribute === 'Card ID'
+                ? parseCardList(value).some(entry => cardListEntryMatches(entry, card.CARDID, card.SEASON))
+                : splitConditionValues(value).map(s => normalizeString(s)).filter(Boolean).includes(normalizeString(cardValue))
             return operator === 'in list' ? inList : !inList
         }
         case 'starts with':

--- a/src/lib/helpers/rules.ts
+++ b/src/lib/helpers/rules.ts
@@ -51,9 +51,9 @@ export interface Rule {
 
 export interface AdvancedRuleData {
     region?: string
-    regionCardIds?: Map<string, Set<number>>
+    regionCardIds?: Map<string, Set<string>>
     flag?: string
-    flagCardIds?: Map<string, Set<number>>
+    flagCardIds?: Map<string, Set<string>>
     bid?: number
     owners?: number
 }
@@ -93,14 +93,16 @@ function collectCacheKeys(
 
 function evaluateCachedMembership(
     cardId: number,
+    season: string | number,
     operator: Operator,
     value: string,
     normalize: (value: string) => string,
-    cacheMap?: Map<string, Set<number>>
+    cacheMap?: Map<string, Set<string>>
 ): boolean | undefined {
     if (!cacheMap || !CACHEABLE_OPERATORS.has(operator)) return undefined
 
-    const hasValue = (key: string) => cacheMap.get(normalize(key))?.has(cardId) || false
+    const cardKey = `${cardId},${season}`
+    const hasValue = (key: string) => cacheMap.get(normalize(key))?.has(cardKey) || false
     if (operator === '=') return hasValue(value)
     if (operator === '!=') return !hasValue(value)
 
@@ -170,14 +172,14 @@ export function evaluateCondition(
             cardValue = Number(card.CARDID)
             break
         case 'Region':
-            const regionMatch = evaluateCachedMembership(Number(card.CARDID), operator, value, canonicalize, advancedData?.regionCardIds)
+            const regionMatch = evaluateCachedMembership(Number(card.CARDID), card.SEASON, operator, value, canonicalize, advancedData?.regionCardIds)
             if (regionMatch !== undefined) return regionMatch
 
             cardValue = advancedData?.region?.toLowerCase() || ''
             value = value.toLowerCase()
             break
         case 'Flag':
-            const flagMatch = evaluateCachedMembership(Number(card.CARDID), operator, value, flag => flag.trim(), advancedData?.flagCardIds)
+            const flagMatch = evaluateCachedMembership(Number(card.CARDID), card.SEASON, operator, value, flag => flag.trim(), advancedData?.flagCardIds)
             if (flagMatch !== undefined) return flagMatch
 
             cardValue = advancedData?.flag || ''

--- a/src/lib/helpers/rules.ts
+++ b/src/lib/helpers/rules.ts
@@ -67,9 +67,22 @@ const LIST_OPERATORS = new Set<Operator>(['in list', 'not in list'])
 const CACHEABLE_OPERATORS = new Set<Operator>(['=', '!=', 'in list', 'not in list'])
 const NUMERIC_ATTRIBUTES = new Set<Attribute>(['Season', 'Card ID', 'Owner Count', 'Bid', 'Market Value'])
 const DETAIL_ATTRIBUTES = new Set<Attribute>(['Bid', 'Owner Count'])
+const SUMMARY_LIST_PREVIEW_COUNT = 3
 
 function splitConditionValues(value: string): string[] {
     return value.split(/[\n,]+/)
+}
+
+function formatListSummary(attribute: Attribute, value: string): string {
+    if (attribute === 'Card ID') {
+        const count = parseCardList(value).length
+        return count === 1 ? '1 card' : `${count} cards`
+    }
+
+    const values = splitConditionValues(value).map(s => s.trim()).filter(Boolean)
+    if (values.length <= SUMMARY_LIST_PREVIEW_COUNT) return values.join(', ')
+
+    return `${values.slice(0, SUMMARY_LIST_PREVIEW_COUNT).join(', ')} + ${values.length - SUMMARY_LIST_PREVIEW_COUNT} more`
 }
 
 function collectCacheKeys(
@@ -262,6 +275,7 @@ export function getRuleSummary(rule: Rule): string {
     const parts = rule.conditions.map(c => {
         let val = c.value
         if (c.attribute === 'Rarity' && !val) val = '(any)'
+        if (LIST_OPERATORS.has(c.operator)) val = formatListSummary(c.attribute, val)
         if ((c.attribute === 'Market Value' || c.attribute === 'Bid') && val && !isNaN(parseFloat(val))) {
             val = parseFloat(val).toFixed(2)
         }

--- a/src/routes/tools/junkdajunk/+page.svelte
+++ b/src/routes/tools/junkdajunk/+page.svelte
@@ -22,10 +22,12 @@
 		getRuleFlagCacheKeys,
 		getRuleRegionCacheKeys,
 		getRuleSummary,
+		isFlagCacheableCondition,
 		isRegionCacheableCondition,
 		ruleNeedsCardDetailsForCard,
 		type Action,
 		type AdvancedRuleData,
+		type Condition,
 		type Rule,
 	} from '$lib/helpers/rules'
 	import {
@@ -198,7 +200,12 @@
 		})
 	}
 
-	function rewriteRegionRulesWithCardIds(sourceRules: Rule[], regionCardIds: Map<string, Set<string>>): Rule[] {
+	function rewriteCachedRulesWithCardIds(
+		sourceRules: Rule[],
+		cardIdsByKey: Map<string, Set<string>>,
+		isCacheableCondition: (condition: Condition) => boolean,
+		normalize: (value: string) => string
+	): Rule[] {
 		let changed = false
 
 		const rewrittenRules = sourceRules.map(rule => {
@@ -207,13 +214,16 @@
 			let ruleChanged = false
 
 			const conditions = rule.conditions.map(condition => {
-				if (!isRegionCacheableCondition(condition)) return condition
+				if (!isCacheableCondition(condition)) return condition
 
-				const regions = ['in list', 'not in list'].includes(condition.operator)
-					? condition.value.split(/[\n,]+/).map(value => canonicalize(value)).filter(Boolean)
-					: [canonicalize(condition.value)]
+				const keys = ['in list', 'not in list'].includes(condition.operator)
+					? condition.value
+							.split(/[\n,]+/)
+							.map(value => normalize(value))
+							.filter(Boolean)
+					: [normalize(condition.value)].filter(Boolean)
 				const ids = new Set<string>()
-				regions.forEach(region => regionCardIds.get(region)?.forEach(id => ids.add(id)))
+				keys.forEach(key => cardIdsByKey.get(key)?.forEach(id => ids.add(id)))
 				changed = true
 				ruleChanged = true
 
@@ -229,6 +239,14 @@
 		})
 
 		return changed ? rewrittenRules : sourceRules
+	}
+
+	function rewriteRegionRulesWithCardIds(sourceRules: Rule[], regionCardIds: Map<string, Set<string>>): Rule[] {
+		return rewriteCachedRulesWithCardIds(sourceRules, regionCardIds, isRegionCacheableCondition, canonicalize)
+	}
+
+	function rewriteFlagRulesWithCardIds(sourceRules: Rule[], flagCardIds: Map<string, Set<string>>): Rule[] {
+		return rewriteCachedRulesWithCardIds(sourceRules, flagCardIds, isFlagCacheableCondition, flag => flag.trim())
 	}
 
 	function findCommaSeparatedCardIdRule(rulesToCheck: Rule[]): number | undefined {
@@ -344,10 +362,13 @@
 				)
 				rules = rewriteRegionRulesWithCardIds(rules, regionCardIds)
 				flagCardIds = await fetchKotamaCardIdCache(flags.map(f => ({ key: f, clause: `flag-IS-${f}` })))
-			} else if (regionalWhitelist.length > 0) {
-				regionCardIds = await fetchKotamaCardIdCache(
-					regionalWhitelist.map(r => ({ key: r, clause: `region-IS-${r.replaceAll('_', ' ')}` }))
-				)
+				rules = rewriteFlagRulesWithCardIds(rules, flagCardIds)
+			} else {
+				if (regionalWhitelist.length > 0) {
+					regionCardIds = await fetchKotamaCardIdCache(
+						regionalWhitelist.map(r => ({ key: r, clause: `region-IS-${r.replaceAll('_', ' ')}` }))
+					)
+				}
 				if (flagWhitelist.length > 0) {
 					flagCardIds = await fetchKotamaCardIdCache(flagWhitelist.map(f => ({ key: f, clause: `flag-IS-${f}` })))
 				}

--- a/src/routes/tools/junkdajunk/+page.svelte
+++ b/src/routes/tools/junkdajunk/+page.svelte
@@ -14,6 +14,7 @@
 	import ToolContent from '$lib/components/ToolContent.svelte'
 	import * as AlertDialog from '$lib/components/ui/alert-dialog'
 	import Button from '$lib/components/ui/button/button.svelte'
+	import { cardListEntryMatches, parseCardList } from '$lib/helpers/cardList'
 	import { giftCard } from '$lib/helpers/gift'
 	import { parseXML, sleep } from '$lib/helpers/parser'
 	import {
@@ -21,6 +22,7 @@
 		getRuleFlagCacheKeys,
 		getRuleRegionCacheKeys,
 		getRuleSummary,
+		isRegionCacheableCondition,
 		ruleNeedsCardDetailsForCard,
 		type Action,
 		type AdvancedRuleData,
@@ -188,6 +190,66 @@
 		return cardIds
 	}
 
+	function sortCardIds(cardIds: string[]): string[] {
+		return cardIds.sort((a, b) => {
+			const [aId, aSeason] = a.split(',').map(Number)
+			const [bId, bSeason] = b.split(',').map(Number)
+			return aSeason - bSeason || aId - bId
+		})
+	}
+
+	function rewriteRegionRulesWithCardIds(sourceRules: Rule[], regionCardIds: Map<string, Set<string>>): Rule[] {
+		let changed = false
+
+		const rewrittenRules = sourceRules.map(rule => {
+			if (!rule.enabled) return rule
+			const originalSummary = getRuleSummary(rule)
+			let ruleChanged = false
+
+			const conditions = rule.conditions.map(condition => {
+				if (!isRegionCacheableCondition(condition)) return condition
+
+				const regions = ['in list', 'not in list'].includes(condition.operator)
+					? condition.value.split(/[\n,]+/).map(value => canonicalize(value)).filter(Boolean)
+					: [canonicalize(condition.value)]
+				const ids = new Set<string>()
+				regions.forEach(region => regionCardIds.get(region)?.forEach(id => ids.add(id)))
+				changed = true
+				ruleChanged = true
+
+				return {
+					...condition,
+					attribute: 'Card ID' as const,
+					operator: ['=', 'in list'].includes(condition.operator) ? 'in list' as const : 'not in list' as const,
+					value: sortCardIds([...ids]).join('\n'),
+				}
+			})
+
+			return ruleChanged ? { ...rule, name: rule.name || originalSummary, conditions } : rule
+		})
+
+		return changed ? rewrittenRules : sourceRules
+	}
+
+	function findCommaSeparatedCardIdRule(rulesToCheck: Rule[]): number | undefined {
+		const ruleIndex = rulesToCheck.findIndex(
+			rule =>
+				rule.enabled &&
+				rule.conditions.some(condition => {
+					if (condition.attribute !== 'Card ID' || !['in list', 'not in list'].includes(condition.operator)) return false
+					return condition.value
+						.split('\n')
+						.map(line => line.trim())
+						.filter(Boolean)
+						.some(line => {
+							const parts = line.split(',').map(part => part.trim()).filter(Boolean)
+							return parts.length > 1 && !(parts.length === 2 && cardSeasons.includes(parts[1]))
+						})
+				})
+		)
+		return ruleIndex === -1 ? undefined : ruleIndex
+	}
+
 	async function onSubmit(e: Event) {
 		if (downloadable) {
 			dialogOpen = true
@@ -238,10 +300,26 @@
 		// for (const [rarity, bid] of Object.entries(raritiesLowestBid))
 		// 	newInfo.push({ text: `${rarity} junk threshold at ${bid}` })
 
-		const findSplit = finderlist.split('\n').map(matcher => matcher.split(','))
-		const whitelistSet = new Set(findSplit.map(f => `${f[0]},${f[1] || ''}`))
+		const findSplit = parseCardList(finderlist)
+		const whitelistSet = new Set(findSplit.map(f => `${f.id},${f.season || ''}`))
 
 		info = newInfo
+
+		if (configMode === 'Rules') {
+			const commaSeparatedRuleIndex = findCommaSeparatedCardIdRule(rules)
+			if (commaSeparatedRuleIndex !== undefined) {
+				info = [
+					...info,
+					{
+						text: `Rule ${commaSeparatedRuleIndex + 1} looks like it uses comma-separated Card ID values. Put one card per line, optionally as id,season.`,
+						color: 'red',
+					},
+				]
+				stoppable = false
+				window.removeEventListener('beforeunload', beforeUnload)
+				return
+			}
+		}
 
 		let junkedCards = 0
 		let giftedCards = 0
@@ -264,6 +342,7 @@
 				regionCardIds = await fetchKotamaCardIdCache(
 					regions.map(r => ({ key: r, clause: `region-IS-${r.replaceAll('_', ' ')}` }))
 				)
+				rules = rewriteRegionRulesWithCardIds(rules, regionCardIds)
 				flagCardIds = await fetchKotamaCardIdCache(flags.map(f => ({ key: f, clause: `flag-IS-${f}` })))
 			} else if (regionalWhitelist.length > 0) {
 				regionCardIds = await fetchKotamaCardIdCache(
@@ -557,17 +636,11 @@
 							}
 
 							findSplit.forEach(findid => {
-								const matchSeason = findid[1]
-								if (findid[0] === String(id)) {
-									if (matchSeason) {
-										if (matchSeason === String(season)) {
-											junk = false
-											reason = `is whitelisted card ${findid[0]} season ${season}`
-										}
-									} else {
-										junk = false
-										reason = `is whitelisted card ${findid}`
-									}
+								if (cardListEntryMatches(findid, id, season)) {
+									junk = false
+									reason = findid.season
+										? `is whitelisted card ${findid.id} season ${season}`
+										: `is whitelisted card ${findid.id}`
 								}
 							})
 						}
@@ -656,8 +729,8 @@
 								if (mode === 'Gift' || (mode === 'Gift and Sell' && sell === true)) {
 									let giftto = gifteeQueue[0]
 									findSplit.forEach(findid => {
-										const matchGiftee = findid[2]
-										if (findid[0] === String(id)) {
+										const matchGiftee = findid.extra[0]
+										if (findid.id === String(id)) {
 											if (matchGiftee) giftto = matchGiftee
 										}
 									})

--- a/src/routes/tools/junkdajunk/+page.svelte
+++ b/src/routes/tools/junkdajunk/+page.svelte
@@ -77,6 +77,8 @@
 		cards?: Array<{ id: number }>
 	}
 
+	const cardSeasons = ['1', '2', '3', '4']
+
 	$effect(() => {
 		if (rulesLoaded) localStorage.setItem('junkdajunkRules', JSON.stringify(rules))
 	})
@@ -126,7 +128,7 @@
 			: defaultPrices
 		owners = page.url.searchParams.get('owners') || (localStorage.getItem('junkdajunkOwnerCount') as string) || ''
 		cardcount = page.url.searchParams.get('cardcount') || (localStorage.getItem('junkdajunkCardCount') as string) || ''
-		const validSeasons = new Set(['1', '2', '3', '4'])
+		const validSeasons = new Set(cardSeasons)
 		const rawSeasons = page.url.searchParams.get('skipseason') ?? localStorage.getItem('junkdajunkOmittedSeasons') ?? ''
 		skipseason = Array.from(new Set(rawSeasons.split(',').filter(s => validSeasons.has(s))))
 		skipexnation =
@@ -146,36 +148,41 @@
 	})
 	onDestroy(() => abortController.abort())
 
-	async function fetchKotamaCardIds(clause: string, from?: string): Promise<Set<number>> {
+	async function fetchKotamaCardIds(clause: string, season: string): Promise<Set<string>> {
 		const params = new URLSearchParams({
 			select: 'min',
 			clauses: clause,
 			ua: main,
 			limit: '252525252525',
+			from: `S${season}`,
 		})
-		if (from) params.set('from', from)
 		const response = await fetch(`https://kotama.kractero.com/api?${params}`, {
 			signal: abortController.signal,
 		})
 		if (!response.ok) throw new Error(`Kotama returned ${response.status} for ${clause}`)
 		const data: KotamaCardList = await response.json()
-		return new Set((data.cards || []).map(card => Number(card.id)))
+		return new Set((data.cards || []).map(card => `${Number(card.id)},${season}`))
 	}
 
 	async function fetchKotamaCardIdCache(
-		entries: { key: string; clause: string; from?: string }[]
-	): Promise<Map<string, Set<number>>> {
-		const cardIds = new Map<string, Set<number>>()
+		entries: { key: string; clause: string }[]
+	): Promise<Map<string, Set<string>>> {
+		const cardIds = new Map<string, Set<string>>()
 		if (entries.length === 0) return cardIds
 
 		progress = [...progress, { text: `Fetching card IDs for ${entries.length} checks...` }]
 
-		for (const { key, clause, from } of entries) {
+		for (const { key, clause } of entries) {
+			const ids = new Set<string>()
+			for (const season of cardSeasons) {
+				if (abortController.signal.aborted || stopped) break
+				const seasonalIds = await fetchKotamaCardIds(clause, season)
+				seasonalIds.forEach(id => ids.add(id))
+				await sleep(0.6)
+			}
 			if (abortController.signal.aborted || stopped) break
-			const ids = await fetchKotamaCardIds(clause, from)
 			cardIds.set(key, ids)
 			progress = [...progress, { text: `Cached ${ids.size} cards for ${key}` }]
-			await sleep(0.6)
 		}
 
 		return cardIds
@@ -241,8 +248,8 @@
 		let actionCount = 0
 		let currCard = 0
 		let currSellCard = 0
-		let regionCardIds = new Map<string, Set<number>>()
-		let flagCardIds = new Map<string, Set<number>>()
+		let regionCardIds = new Map<string, Set<string>>()
+		let flagCardIds = new Map<string, Set<string>>()
 
 		let gifteeQueue = giftee
 			.split('\n')
@@ -458,11 +465,11 @@
 									reason: `category set to gift`,
 								},
 								{
-									check: () => regionCardIds.size > 0 && [...regionCardIds.values()].some(set => set.has(Number(id))),
+									check: () => regionCardIds.size > 0 && [...regionCardIds.values()].some(set => set.has(`${Number(id)},${season}`)),
 									reason: `is in whitelisted region`,
 								},
 								{
-									check: () => flagCardIds.size > 0 && [...flagCardIds.values()].some(set => set.has(Number(id))),
+									check: () => flagCardIds.size > 0 && [...flagCardIds.values()].some(set => set.has(`${Number(id)},${season}`)),
 									reason: `is in whitelisted flag`,
 								},
 								{


### PR DESCRIPTION
This:
- fixes region/flag fetching by properly doing it by season and storing season with card id
- in Rules mode, rewrites the rules to directly be the list of card IDs rather than the region name, to avoid future fetches